### PR TITLE
Support for LSP completion requests

### DIFF
--- a/shared/src/main/scala/kiama/util/Positions.scala
+++ b/shared/src/main/scala/kiama/util/Positions.scala
@@ -38,6 +38,14 @@ case class Position(line: Int, column: Int, source: Source) {
     source.optLineContents(line).map(s => s"$s\n${" " * (column - 1)}^")
 
   /**
+   * Return the word at the given position. A word is any string surrounded by
+   * whitespaces. TODO: Make this more general
+   * If the source provides no access to its lines, return `None`.
+   */
+  lazy val optWord: Option[String] =
+    source.optLineContents(line).map(s => s.split(" ").last)
+
+  /**
    * Return the offset that this position refers to in its source. `None`
    * is returned if the position is not valid for its source.
    */

--- a/shared/src/main/scala/kiama/util/Positions.scala
+++ b/shared/src/main/scala/kiama/util/Positions.scala
@@ -38,14 +38,6 @@ case class Position(line: Int, column: Int, source: Source) {
     source.optLineContents(line).map(s => s"$s\n${" " * (column - 1)}^")
 
   /**
-   * Return the word at the given position. A word is any string surrounded by
-   * whitespaces. TODO: Make this more general
-   * If the source provides no access to its lines, return `None`.
-   */
-  lazy val optWord: Option[String] =
-    source.optLineContents(line).map(s => s.split(" ").last)
-
-  /**
    * Return the offset that this position refers to in its source. `None`
    * is returned if the position is not valid for its source.
    */


### PR DESCRIPTION
This PR is part of https://github.com/effekt-lang/effekt/pull/384 and adds LSP completion request handlers for kiama.

I wonder if there's a more elegant (or already implemented?) solution for `optWord`? This is relevant for filtering the suggested symbols (e.g. by prefix). Just for testing I split by whitespace, but this should ultimately also consider dots, semicolons, etc.
