### PR TITLE
Fix Position.between

### DIFF
--- a/shared/src/main/scala/kiama/util/Positions.scala
+++ b/shared/src/main/scala/kiama/util/Positions.scala
@@ -45,32 +45,40 @@ case class Position(line: Int, column: Int, source: Source) {
     source.positionToOffset(this)
 
   /**
-   * Apply a binary Boolean operation to this position and another one,
-   * as offsets, return the result.
+   * Does this position occur no later than `p`? The two positions
+   * are assumed to refer to the same source.
+   * If the second position falls outside the source, but the first
+   * one is inside, the first one is considered to be before the second.
+   * False is returned if both positions are invalid.
    */
-  def op2(op: (Int, Int) => Boolean, p: Position): Boolean =
+  def <=(p: Position): Boolean = {
     (optOffset, p.optOffset) match {
       case (Some(l), Some(r)) =>
-        op(l, r)
+        l <= r
+      case (Some(_), None) =>
+        true
       case (l, r) =>
         false
     }
-
-  /**
-   * Does this position occur no later than `p`? The two positions
-   * are assumed to refer to the same source. False is returned if one
-   * of the positions is invalid.
-   */
-  def <=(p: Position): Boolean =
-    op2(_ <= _, p)
+  }
 
   /**
    * Does this position occur before `p`? The two positions are assumed
-   * to refer to the same source. False is returned if one of the
-   * positions is invalid.
+   * to refer to the same source.
+   * If the second position falls outside the source, but the first
+   * one is inside, the first one is considered to be before the second.
+   * False is returned if both positions are invalid.
    */
-  def <(p: Position): Boolean =
-    op2(_ < _, p)
+  def <(p: Position): Boolean = {
+    (optOffset, p.optOffset) match {
+      case (Some(l), Some(r)) =>
+        l < r
+      case (Some(_), None) =>
+        true
+      case (l, r) =>
+        false
+    }
+  }
 
   /**
    * Does this position occur between two other positions, in the same
@@ -78,7 +86,6 @@ case class Position(line: Int, column: Int, source: Source) {
    */
   def between(start: Position, finish: Position): Boolean =
     (start <= this) && (this < finish)
-
 }
 
 case class Range(from: Position, to: Position)


### PR DESCRIPTION
When the language server compiles on `didSave` rather than `didChange`, the following situation can occur:
The client requests inlay hints for a range in that falls outside of the text before the change.
Usually, the end position of the range is no longer within the bounds of the previous document.
Previously, no inlay hints would be returned for such ranges because `Positions.between` would return `false` for these.
With this change, we consider any position within the known document bounds to be less than (or equal) to any position outside of the known document bounds.
