### PR TITLE
Custom equality for FileSource

### DIFF
--- a/shared/src/main/scala/kiama/util/Source.scala
+++ b/shared/src/main/scala/kiama/util/Source.scala
@@ -132,5 +132,5 @@ case class FileSource(name: String, encoding: String = "UTF-8") extends Source {
 
   override def hashCode(): Int =
     // combine canonical path and encoding
-    (canonicalFile, encoding).##
+    (canonicalFile, encoding).hashCode
 }

--- a/shared/src/main/scala/kiama/util/Source.scala
+++ b/shared/src/main/scala/kiama/util/Source.scala
@@ -124,13 +124,11 @@ case class FileSource(name: String, encoding: String = "UTF-8") extends Source {
 
   override def equals(other: Any): Boolean = other match {
     case that: FileSource =>
-      this.canonicalFile == that.canonicalFile &&
-      this.encoding      == that.encoding
+      this.canonicalFile == that.canonicalFile
     case _ =>
       false
   }
 
   override def hashCode(): Int =
-    // combine canonical path and encoding
-    (canonicalFile, encoding).hashCode
+    canonicalFile.hashCode
 }

--- a/shared/src/main/scala/kiama/util/Source.scala
+++ b/shared/src/main/scala/kiama/util/Source.scala
@@ -11,6 +11,8 @@
 package kiama
 package util
 
+import java.io.File
+
 /**
  * A simple source of characters.
  */
@@ -106,8 +108,29 @@ case class BufferSource(contents: GapBuffer, name: String = "") extends Source {
  * A source that is a named file.
  */
 case class FileSource(name: String, encoding: String = "UTF-8") extends Source {
-
   val shortName = Filenames.dropCurrentPath(name)
-
   lazy val content = scala.io.Source.fromFile(name, encoding).mkString
+
+  // Custom equals and hashCode to compare FileSource instances
+  //
+  // This is necessary to ensure that the same FileSource is recognized even if it is referenced with different
+  // filenames (such as "foo.effekt", "./foo.effekt", or "/abs/path/to/foo.effekt")
+
+  // The canonical (absolute, symlink-resolved) file
+  private lazy val canonicalFile: File =
+    new File(name).getCanonicalFile
+
+  override def canEqual(other: Any): Boolean = other.isInstanceOf[FileSource]
+
+  override def equals(other: Any): Boolean = other match {
+    case that: FileSource =>
+      this.canonicalFile == that.canonicalFile &&
+      this.encoding      == that.encoding
+    case _ =>
+      false
+  }
+
+  override def hashCode(): Int =
+    // combine canonical path and encoding
+    (canonicalFile, encoding).##
 }


### PR DESCRIPTION
In `Namer`, we have some logic to check for cyclic imports. This check currently structurally compares `Module`s. In https://github.com/effekt-lang/effekt/pull/957, modules contain now spans which reference a `Source`.
Each source has a `name`.
Now, depending on whether a source is loaded directly or via an import, the `name` field can differ (e.g. `foo.effekt` vs. `./foo.effekt`.
This PR implements a custom equality on `FileSource` which considers two `FileSource`s as equal when they point to the same canonical path and have the same encoding.
Not sure if this is the best solution.