### PR TITLE
Fix finding nodes in range

### DIFF
--- a/shared/src/main/scala/kiama/util/Positions.scala
+++ b/shared/src/main/scala/kiama/util/Positions.scala
@@ -250,8 +250,8 @@ class Positions {
   def findNodesInRange[T](nodes: Vector[T], range: Range): Vector[T] =
     nodes.collect { t =>
       (getStart(t), getFinish(t)) match {
-        case (Some(start), Some(finish)) if start.between(range.from, range.to) && finish.between(range.from, range.to) =>
-          t
+        case (Some(start), Some(finish)) if start.between(range.from, range.to) && (range.from <= finish) && (finish <= range.to)
+          => t
       }
     }
 


### PR DESCRIPTION
`findNodesInRange` currently doesn't consider a range `r1` to be contained in `r2` if `r1.to = r2.to`. This is because it uses `finish.between(range.from, range.to)` which compares `finish < range.to` rather than `finish <= range.to`.